### PR TITLE
[NEST-BE-29] Create API endpoint for adding UserPost and Article in their bookmarks

### DIFF
--- a/src/main/java/com/nest/core/member_management_service/model/Member.java
+++ b/src/main/java/com/nest/core/member_management_service/model/Member.java
@@ -51,6 +51,9 @@ public class Member {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Report> reports;
 
+    @ManyToMany(mappedBy = "bookmarkedMembers", cascade = CascadeType.ALL)
+    private Set<Post> bookmarkedPosts;
+
     @PostLoad
     @PrePersist
     public void presetAvatar(){

--- a/src/main/java/com/nest/core/post_management_service/controller/ArticleApiController.java
+++ b/src/main/java/com/nest/core/post_management_service/controller/ArticleApiController.java
@@ -5,6 +5,7 @@ import com.nest.core.member_management_service.model.MemberRole;
 import com.nest.core.post_management_service.dto.CreateArticleRequest;
 import com.nest.core.post_management_service.dto.EditArticleRequest;
 import com.nest.core.post_management_service.dto.EditArticleResponse;
+import com.nest.core.post_management_service.exception.AddBookmarkFailException;
 import com.nest.core.post_management_service.exception.CreateArticleFailException;
 import com.nest.core.post_management_service.exception.DeleteArticleFailException;
 import com.nest.core.post_management_service.exception.EditArticleFailException;
@@ -80,6 +81,22 @@ public class ArticleApiController {
                 return ResponseEntity.ok("Article deleted");
             } catch (Exception e) {
                 throw new DeleteArticleFailException("Failed to delete article: " + e.getMessage());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+
+    @PostMapping("/bookmark/add/{postId}")
+    public ResponseEntity<?> bookmarkArticle(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long postId) {
+        if (userDetails instanceof CustomSecurityUserDetails customUser) {
+            Long userId = customUser.getUserId();
+            try {
+                articleService.addBookmark(postId, userId);
+                return ResponseEntity.ok("Post bookmarked");
+
+            } catch (Exception e) {
+                throw new AddBookmarkFailException("Failed to save bookmark: " + e.getMessage());
             }
         } else {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");

--- a/src/main/java/com/nest/core/post_management_service/controller/PostApiController.java
+++ b/src/main/java/com/nest/core/post_management_service/controller/PostApiController.java
@@ -3,6 +3,7 @@ package com.nest.core.post_management_service.controller;
 import com.nest.core.auth_service.dto.CustomSecurityUserDetails;
 import com.nest.core.post_management_service.dto.CreatePostRequest;
 import com.nest.core.post_management_service.dto.EditPostRequest;
+import com.nest.core.post_management_service.exception.AddBookmarkFailException;
 import com.nest.core.post_management_service.exception.CreateArticleFailException;
 import com.nest.core.post_management_service.exception.CreatePostFailException;
 import com.nest.core.post_management_service.exception.EditArticleFailException;
@@ -74,6 +75,21 @@ public class PostApiController {
                 return ResponseEntity.ok("Post deleted");
             } catch (Exception e){
                 throw new EditArticleFailException("Failed to delete post: " + e.getMessage());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+
+    @PostMapping("/bookmark/add/{postId}")
+    public ResponseEntity<?> bookmarkPost(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long postId) {
+        if (userDetails instanceof CustomSecurityUserDetails customUser) {
+            Long userId = customUser.getUserId();
+            try {
+                postService.addBookmark(postId, userId);
+                return ResponseEntity.ok("Post bookmarked");
+            } catch (Exception e) {
+                throw new AddBookmarkFailException("Failed to save bookmark: " + e.getMessage());
             }
         } else {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");

--- a/src/main/java/com/nest/core/post_management_service/exception/AddBookmarkFailException.java
+++ b/src/main/java/com/nest/core/post_management_service/exception/AddBookmarkFailException.java
@@ -1,0 +1,7 @@
+package com.nest.core.post_management_service.exception;
+
+public class AddBookmarkFailException extends RuntimeException {
+    public AddBookmarkFailException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nest/core/post_management_service/model/Post.java
+++ b/src/main/java/com/nest/core/post_management_service/model/Post.java
@@ -43,6 +43,14 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<PostImage> postImages;
 
+    @ManyToMany
+    @JoinTable(
+            name = "bookmark",
+            joinColumns = @JoinColumn(name = "post_id"),
+            inverseJoinColumns = @JoinColumn(name = "member_id")
+    )
+    private Set<Member> bookmarkedMembers;
+
     private String type;
 
     @Column(name="likes_count")

--- a/src/main/java/com/nest/core/post_management_service/service/ArticleService.java
+++ b/src/main/java/com/nest/core/post_management_service/service/ArticleService.java
@@ -10,6 +10,7 @@ import com.nest.core.post_management_service.dto.CreateArticleRequest;
 import com.nest.core.post_management_service.dto.EditArticleRequest;
 import com.nest.core.post_management_service.dto.EditArticleResponse;
 import com.nest.core.post_management_service.dto.GetArticleResponse;
+import com.nest.core.post_management_service.exception.AddBookmarkFailException;
 import com.nest.core.post_management_service.exception.DeleteArticleFailException;
 import com.nest.core.post_management_service.exception.EditArticleFailException;
 import com.nest.core.post_management_service.model.Post;
@@ -133,6 +134,18 @@ public class ArticleService {
         postRepository.delete(post);
     }
 
+    public void addBookmark(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new AddBookmarkFailException("Post not found"));
+
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new AddBookmarkFailException("Member not found"));
+
+        member.getBookmarkedPosts().add(post);
+        post.getBookmarkedMembers().add(member);
+        memberRepository.save(member);
+        postRepository.save(post);
+    }
 
     private Set<Tag> createOrFindTags(Set<String> tagNames) {
         if (tagNames == null || tagNames.isEmpty()) {

--- a/src/main/java/com/nest/core/post_management_service/service/ArticleService.java
+++ b/src/main/java/com/nest/core/post_management_service/service/ArticleService.java
@@ -136,10 +136,14 @@ public class ArticleService {
 
     public void addBookmark(Long postId, Long userId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new AddBookmarkFailException("Post not found"));
+                .orElseThrow(() -> new AddBookmarkFailException("Article not found"));
 
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new AddBookmarkFailException("Member not found"));
+
+        if (post.getBookmarkedMembers().contains(member)) {
+            throw new AddBookmarkFailException("Article already bookmarked");
+        }
 
         member.getBookmarkedPosts().add(post);
         post.getBookmarkedMembers().add(member);

--- a/src/main/java/com/nest/core/post_management_service/service/PostService.java
+++ b/src/main/java/com/nest/core/post_management_service/service/PostService.java
@@ -112,6 +112,10 @@ public class PostService {
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new AddBookmarkFailException("Member not found"));
 
+        if (post.getBookmarkedMembers().contains(member)) {
+            throw new AddBookmarkFailException("Post already bookmarked");
+        }
+
         member.getBookmarkedPosts().add(post);
         post.getBookmarkedMembers().add(member);
         memberRepository.save(member);

--- a/src/main/java/com/nest/core/post_management_service/service/PostService.java
+++ b/src/main/java/com/nest/core/post_management_service/service/PostService.java
@@ -105,6 +105,18 @@ public class PostService {
         postRepository.delete(post);
     }
 
+    public void addBookmark(Long postId, Long userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new AddBookmarkFailException("Post not found"));
+
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new AddBookmarkFailException("Member not found"));
+
+        member.getBookmarkedPosts().add(post);
+        post.getBookmarkedMembers().add(member);
+        memberRepository.save(member);
+        postRepository.save(post);
+    }
 
     /**
      * Helper methods


### PR DESCRIPTION
- Created endpoint at post(article)/bookmark/add/{postId}
- For removing bookmarks for ticket NEST-BE-30 the planned route is post(article)/bookmark/remove/{postId}
- The code for both post and articles were very similiar, maybe there's a better way of doing this?
- I used @ManyToMany mapping annotation to write to bookmark, let me know if you want me to change it
- I noticed some of the exceptions being thrown in post services were throwing ArticleFail not PostFail, is there a reason to have 2 separate exceptions?