### PR TITLE
[NEST-BE-33] Create API endpoint for reading reported UserPost and Article for moderator

### DIFF
--- a/src/main/java/com/nest/core/auth_service/config/SecurityConfig.java
+++ b/src/main/java/com/nest/core/auth_service/config/SecurityConfig.java
@@ -96,6 +96,21 @@ public class SecurityConfig {
                         .requestMatchers(
                                 HttpMethod.GET,"/api/v1/article"
                         ).permitAll()
+                        // Report-Management-Service
+                        .requestMatchers(
+                                HttpMethod.GET, "/api/v1/report/post/**"
+                        ).hasAnyRole(MemberRole.ADMIN.name(), MemberRole.MODERATOR.name(), MemberRole.SUPER_ADMIN.name())
+                        .requestMatchers(
+                                HttpMethod.GET, "/api/v1/report/article/**"
+                        ).hasAnyRole(MemberRole.ADMIN.name(), MemberRole.MODERATOR.name(), MemberRole.SUPER_ADMIN.name())
+                        .requestMatchers(
+                                HttpMethod.DELETE, "/api/v1/report/**"
+                        ).hasAnyRole(MemberRole.ADMIN.name(), MemberRole.MODERATOR.name(), MemberRole.SUPER_ADMIN.name())
+                        .requestMatchers(
+                                HttpMethod.POST, "/api/v1/report/post/**"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/report/article/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 ).exceptionHandling(exceptionHandling -> exceptionHandling
                         .authenticationEntryPoint((request, response, authException) -> {

--- a/src/main/java/com/nest/core/report_management_service/controller/ReportApiController.java
+++ b/src/main/java/com/nest/core/report_management_service/controller/ReportApiController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.*;
 
 import com.nest.core.auth_service.dto.CustomSecurityUserDetails;
 import com.nest.core.report_management_service.dto.ReportPostRequest;
+import com.nest.core.report_management_service.exception.ReportDeleteFailException;
+import com.nest.core.report_management_service.exception.ReportGetFailException;
 import com.nest.core.report_management_service.exception.ReportPostFailException;
 import com.nest.core.report_management_service.service.ReportService;
 
@@ -21,6 +23,49 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/report")
 public class ReportApiController {
     private final ReportService reportService;
+
+    @GetMapping("/post/{postId}")
+    public ResponseEntity<?> getPostReports(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long postId) {
+        if (userDetails instanceof CustomSecurityUserDetails customUser) {
+            Long userId = customUser.getUserId();
+            try {
+                return ResponseEntity.ok(reportService.getPostReports(postId, userId));
+            } catch (Exception e) {
+                throw new ReportGetFailException("Failed to get post reports: " + e.getMessage());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+
+    @GetMapping("/article/{postId}")
+    public ResponseEntity<?> getArticleReports(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long postId) {
+        if (userDetails instanceof CustomSecurityUserDetails customUser) {
+            Long userId = customUser.getUserId();
+            try {
+                return ResponseEntity.ok(reportService.getArticleReports(postId, userId));
+            } catch (Exception e) {
+                throw new ReportGetFailException("Failed to get article reports: " + e.getMessage());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+
+    @DeleteMapping("/{reportId}")
+    public ResponseEntity<?> deleteReport(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long reportId) {
+        if (userDetails instanceof CustomSecurityUserDetails customUser) {
+            Long userId = customUser.getUserId();
+            try {
+                reportService.deleteReport(reportId, userId);
+                return ResponseEntity.ok("Report deleted");
+            } catch (Exception e) {
+                throw new ReportDeleteFailException("Failed to delete report: " + e.getMessage());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
 
     @PostMapping("/post/{postId}")
     public ResponseEntity<?> reportPost(

--- a/src/main/java/com/nest/core/report_management_service/controller/ReportApiController.java
+++ b/src/main/java/com/nest/core/report_management_service/controller/ReportApiController.java
@@ -1,0 +1,51 @@
+package com.nest.core.report_management_service.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import com.nest.core.auth_service.dto.CustomSecurityUserDetails;
+import com.nest.core.report_management_service.dto.ReportPostRequest;
+import com.nest.core.report_management_service.exception.ReportPostFailException;
+import com.nest.core.report_management_service.service.ReportService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/report")
+public class ReportApiController {
+    private final ReportService reportService;
+
+    @PostMapping("/post/{postId}")
+    public ResponseEntity<?> reportPost(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody ReportPostRequest report,
+        @PathVariable Long postId) {
+
+        if (userDetails instanceof CustomSecurityUserDetails customUser) {
+            Long userId = customUser.getUserId();
+            try {
+                reportService.createPostReport(report, userId, postId);
+                return ResponseEntity.ok("Post reported");
+            } catch (Exception e) {
+                throw new ReportPostFailException("Failed to report post: " + e.getMessage());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+
+    @PostMapping("/article/{postId}")
+    public ResponseEntity<?> reportArticle(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody ReportPostRequest report,
+        @PathVariable Long postId) {
+        return reportPost(userDetails, report, postId);
+    }
+}

--- a/src/main/java/com/nest/core/report_management_service/dto/GetArticleReportsResponse.java
+++ b/src/main/java/com/nest/core/report_management_service/dto/GetArticleReportsResponse.java
@@ -1,0 +1,26 @@
+package com.nest.core.report_management_service.dto;
+
+import java.sql.Date;
+
+import com.nest.core.report_management_service.model.Report;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetArticleReportsResponse {
+    private Long id;
+    private Long memberId;
+    private Long postId;
+    private String reason;
+    private Date createdAt;
+
+    public GetArticleReportsResponse(Report report) {
+        this.id = report.getId();
+        this.memberId = report.getMember().getId();
+        this.postId = report.getPost().getId();
+        this.reason = report.getReason();
+        this.createdAt = report.getCreatedAt();
+    }
+}

--- a/src/main/java/com/nest/core/report_management_service/dto/GetPostReportsResponse.java
+++ b/src/main/java/com/nest/core/report_management_service/dto/GetPostReportsResponse.java
@@ -1,0 +1,26 @@
+package com.nest.core.report_management_service.dto;
+
+import java.sql.Date;
+
+import com.nest.core.report_management_service.model.Report;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetPostReportsResponse {
+    private Long id;
+    private Long memberId;
+    private Long postId;
+    private String reason;
+    private Date createdAt;
+
+    public GetPostReportsResponse(Report report) {
+        this.id = report.getId();
+        this.memberId = report.getMember().getId();
+        this.postId = report.getPost().getId();
+        this.reason = report.getReason();
+        this.createdAt = report.getCreatedAt();
+    }
+}

--- a/src/main/java/com/nest/core/report_management_service/dto/ReportPostRequest.java
+++ b/src/main/java/com/nest/core/report_management_service/dto/ReportPostRequest.java
@@ -1,0 +1,26 @@
+package com.nest.core.report_management_service.dto;
+
+import java.sql.Date;
+
+import com.nest.core.member_management_service.model.Member;
+import com.nest.core.post_management_service.model.Post;
+import com.nest.core.report_management_service.model.Report;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportPostRequest {
+
+    private String reason;
+
+    public Report toEntity(Member member, Post post) {
+        return Report.builder()
+                .member(member)
+                .reason(this.reason)
+                .createdAt(new Date(System.currentTimeMillis()))
+                .post(post)
+                .build();
+    }
+}

--- a/src/main/java/com/nest/core/report_management_service/exception/PostNotFoundException.java
+++ b/src/main/java/com/nest/core/report_management_service/exception/PostNotFoundException.java
@@ -1,0 +1,8 @@
+package com.nest.core.report_management_service.exception;
+
+public class PostNotFoundException extends RuntimeException {
+    public PostNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/nest/core/report_management_service/exception/ReportDeleteFailException.java
+++ b/src/main/java/com/nest/core/report_management_service/exception/ReportDeleteFailException.java
@@ -1,0 +1,8 @@
+package com.nest.core.report_management_service.exception;
+
+public class ReportDeleteFailException extends RuntimeException {
+    public ReportDeleteFailException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/nest/core/report_management_service/exception/ReportGetFailException.java
+++ b/src/main/java/com/nest/core/report_management_service/exception/ReportGetFailException.java
@@ -1,0 +1,7 @@
+package com.nest.core.report_management_service.exception;
+
+public class ReportGetFailException extends RuntimeException {
+    public ReportGetFailException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nest/core/report_management_service/exception/ReportPostFailException.java
+++ b/src/main/java/com/nest/core/report_management_service/exception/ReportPostFailException.java
@@ -1,0 +1,7 @@
+package com.nest.core.report_management_service.exception;
+
+public class ReportPostFailException extends RuntimeException {
+    public ReportPostFailException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nest/core/report_management_service/model/Report.java
+++ b/src/main/java/com/nest/core/report_management_service/model/Report.java
@@ -1,10 +1,18 @@
 package com.nest.core.report_management_service.model;
 
+import java.sql.Date;
+
 import com.nest.core.member_management_service.model.Member;
 import com.nest.core.post_management_service.model.Post;
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name="report")
 public class Report {
 
@@ -19,4 +27,14 @@ public class Report {
     @ManyToOne
     @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)
     private Member member;
+
+    @Builder.Default
+    @Column(name = "comment_id")
+    private Long commentId = null;
+
+    @Column(name = "reason", nullable = false)
+    private String reason;
+
+    @Column(name = "created_at", nullable = false)
+    private Date createdAt;
 }

--- a/src/main/java/com/nest/core/report_management_service/repository/ReportRepository.java
+++ b/src/main/java/com/nest/core/report_management_service/repository/ReportRepository.java
@@ -1,0 +1,8 @@
+package com.nest.core.report_management_service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nest.core.report_management_service.model.Report;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/nest/core/report_management_service/repository/ReportRepository.java
+++ b/src/main/java/com/nest/core/report_management_service/repository/ReportRepository.java
@@ -1,8 +1,18 @@
 package com.nest.core.report_management_service.repository;
 
+import java.util.List;
+
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import com.nest.core.report_management_service.model.Report;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    @Query("SELECT r FROM Report r WHERE r.post.id = :postId AND r.post.type = 'ARTICLE'")
+    List<Report> findAllArticleReports(@Param("postId") Long articleId);
+
+    @Query("SELECT r FROM Report r WHERE r.post.id = :postId AND r.post.type = 'USERPOST'")
+    List<Report> findAllPostReports(@Param("postId") Long postId);
 }

--- a/src/main/java/com/nest/core/report_management_service/service/ReportService.java
+++ b/src/main/java/com/nest/core/report_management_service/service/ReportService.java
@@ -1,0 +1,57 @@
+package com.nest.core.report_management_service.service;
+
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import com.nest.core.member_management_service.exception.MemberNotFoundException;
+import com.nest.core.member_management_service.model.Member;
+import com.nest.core.member_management_service.repository.MemberRepository;
+import com.nest.core.post_management_service.model.Post;
+import com.nest.core.post_management_service.repository.PostRepository;
+import com.nest.core.report_management_service.dto.ReportPostRequest;
+import com.nest.core.report_management_service.exception.PostNotFoundException;
+import com.nest.core.report_management_service.model.Report;
+import com.nest.core.report_management_service.repository.ReportRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class ReportService {
+    private final ReportRepository reportRepository;
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public void createPostReport(ReportPostRequest reportRequest, Long userId, Long postId) {
+
+        Member member = memberRepository
+                .findById(userId)
+                .orElseThrow(() -> new MemberNotFoundException("Member not found"));
+
+        Post post = postRepository
+                .findById(postId)
+                .orElseThrow(() -> new PostNotFoundException("Post not found"));
+
+        Report report = reportRequest.toEntity(member, post);
+
+        Set<Report> memberReports = member.getReports();
+        for (Report r : memberReports) {
+            if (r.getPost().getId().equals(postId)) {
+                r.setReason(report.getReason());
+                r.setCreatedAt(report.getCreatedAt());
+                reportRepository.save(r);
+                return;
+            }
+        }
+        member.getReports().add(report);
+        member.setReports(member.getReports());
+        reportRepository.save(report);
+        memberRepository.save(member);
+    }
+}


### PR DESCRIPTION
**LAST PULL REQUEST BEFORE MIDTERMS** 🙃
- This was branched off of NEST-BE-31, so that would should be reviewed first before this one 🙃
- Right now I made it only admin, super admin, moderators, can use the get and delete endpoints for reports, check over the security config if i did it correctly
- I separated getting article and getting posts into different endpoints, but logic wise it is the same for the most part so let me know if this is necessary
- I limited the select query to only post/article for their respective repository functions, let me know if this is necessary