### PR TITLE
[NEST-BE-32] Create API endpoint for adding(editing) report comments on UserPost and Article

### DIFF
--- a/src/main/java/com/nest/core/report_management_service/controller/ReportApiController.java
+++ b/src/main/java/com/nest/core/report_management_service/controller/ReportApiController.java
@@ -10,7 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
 
 import com.nest.core.auth_service.dto.CustomSecurityUserDetails;
+import com.nest.core.report_management_service.dto.ReportCommentRequest;
 import com.nest.core.report_management_service.dto.ReportPostRequest;
+import com.nest.core.report_management_service.exception.ReportCommentFailException;
 import com.nest.core.report_management_service.exception.ReportDeleteFailException;
 import com.nest.core.report_management_service.exception.ReportGetFailException;
 import com.nest.core.report_management_service.exception.ReportPostFailException;
@@ -92,5 +94,24 @@ public class ReportApiController {
         @RequestBody ReportPostRequest report,
         @PathVariable Long postId) {
         return reportPost(userDetails, report, postId);
+    }
+
+    @PostMapping("/comment/{commentId}")
+    public ResponseEntity<?> reportComment(@AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody ReportCommentRequest report,
+        @PathVariable Long commentId) {
+
+            if (userDetails instanceof CustomSecurityUserDetails customUser) {
+                Long userId = customUser.getUserId();
+                try {
+                    reportService.createCommentReport(report, userId, commentId);
+                    return ResponseEntity.ok("Comment reported");
+
+                } catch (Exception e) {
+                    throw new ReportCommentFailException("Failed to report comment: " + e.getMessage());
+                }
+            } else {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+            }
     }
 }

--- a/src/main/java/com/nest/core/report_management_service/dto/ReportCommentRequest.java
+++ b/src/main/java/com/nest/core/report_management_service/dto/ReportCommentRequest.java
@@ -1,0 +1,24 @@
+package com.nest.core.report_management_service.dto;
+
+import java.sql.Date;
+
+import com.nest.core.member_management_service.model.Member;
+import com.nest.core.report_management_service.model.Report;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReportCommentRequest {
+    private String reason;
+
+    public Report toEntity(Member member, Long commentId) {
+        return Report.builder()
+            .member(member)
+            .reason(reason)
+            .createdAt(new Date(System.currentTimeMillis()))
+            .commentId(commentId)
+            .build();
+    }
+}

--- a/src/main/java/com/nest/core/report_management_service/exception/CommentNotFoundException.java
+++ b/src/main/java/com/nest/core/report_management_service/exception/CommentNotFoundException.java
@@ -1,0 +1,7 @@
+package com.nest.core.report_management_service.exception;
+
+public class CommentNotFoundException extends RuntimeException {
+    public CommentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nest/core/report_management_service/exception/ReportCommentFailException.java
+++ b/src/main/java/com/nest/core/report_management_service/exception/ReportCommentFailException.java
@@ -1,0 +1,8 @@
+package com.nest.core.report_management_service.exception;
+
+public class ReportCommentFailException extends RuntimeException {
+    public ReportCommentFailException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/nest/core/report_management_service/model/Report.java
+++ b/src/main/java/com/nest/core/report_management_service/model/Report.java
@@ -21,8 +21,9 @@ public class Report {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "post_id", referencedColumnName = "id", nullable = false)
-    private Post post;
+    @Builder.Default
+    @JoinColumn(name = "post_id", referencedColumnName = "id")
+    private Post post = null;
 
     @ManyToOne
     @JoinColumn(name = "member_id", referencedColumnName = "id", nullable = false)


### PR DESCRIPTION
- Had to edit the Report model for post to be nullable since I saw in the DB constraint only one or the other is null
- Uses /comment/{commendId} endpoint to report comments
- Will update a user's report if they report the same comment again