### PR TITLE
[NEST-BE-33] Update endpoint to get reports without ID

### DIFF
--- a/src/main/java/com/nest/core/report_management_service/controller/ReportApiController.java
+++ b/src/main/java/com/nest/core/report_management_service/controller/ReportApiController.java
@@ -40,6 +40,20 @@ public class ReportApiController {
         }
     }
 
+    @GetMapping("/post")
+    public ResponseEntity<?> getAllPostReports(@AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails instanceof CustomSecurityUserDetails customUser) {
+            Long userId = customUser.getUserId();
+            try {
+                return ResponseEntity.ok(reportService.getAllPostReports(userId));
+            } catch (Exception e) {
+                throw new ReportGetFailException("Failed to get all post reports: " + e.getMessage());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+
     @GetMapping("/article/{postId}")
     public ResponseEntity<?> getArticleReports(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long postId) {
         if (userDetails instanceof CustomSecurityUserDetails customUser) {
@@ -48,6 +62,20 @@ public class ReportApiController {
                 return ResponseEntity.ok(reportService.getArticleReports(postId, userId));
             } catch (Exception e) {
                 throw new ReportGetFailException("Failed to get article reports: " + e.getMessage());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+
+    @GetMapping("/article")
+    public ResponseEntity<?> getAllArticleReports(@AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails instanceof CustomSecurityUserDetails customUser) {
+            Long userId = customUser.getUserId();
+            try {
+                return ResponseEntity.ok(reportService.getAllArticleReports(userId));
+            } catch (Exception e) {
+                throw new ReportGetFailException("Failed to get all article reports: " + e.getMessage());
             }
         } else {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
@@ -113,5 +141,19 @@ public class ReportApiController {
             } else {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
             }
+    }
+
+    @GetMapping("/comment")
+    public ResponseEntity<?> getAllCommentReports(@AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails instanceof CustomSecurityUserDetails customUser) {
+            Long userId = customUser.getUserId();
+            try {
+                return ResponseEntity.ok(reportService.getAllCommentReports(userId));
+            } catch (Exception e) {
+                throw new ReportGetFailException("Failed to get all comment reports: " + e.getMessage());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
     }
 }

--- a/src/main/java/com/nest/core/report_management_service/dto/GetCommentReportResponse.java
+++ b/src/main/java/com/nest/core/report_management_service/dto/GetCommentReportResponse.java
@@ -1,0 +1,26 @@
+package com.nest.core.report_management_service.dto;
+
+import java.sql.Date;
+
+import com.nest.core.report_management_service.model.Report;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetCommentReportResponse {
+    private Long id;
+    private Long memberId;
+    private Long commentId;
+    private String reason;
+    private Date createdAt;
+
+    public GetCommentReportResponse(Report report) {
+        this.id = report.getId();
+        this.memberId = report.getMember().getId();
+        this.commentId = report.getCommentId();
+        this.reason = report.getReason();
+        this.createdAt = report.getCreatedAt();
+    }
+}

--- a/src/main/java/com/nest/core/report_management_service/repository/ReportRepository.java
+++ b/src/main/java/com/nest/core/report_management_service/repository/ReportRepository.java
@@ -15,4 +15,13 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
 
     @Query("SELECT r FROM Report r WHERE r.post.id = :postId AND r.post.type = 'USERPOST'")
     List<Report> findAllPostReports(@Param("postId") Long postId);
+
+    @Query("SELECT r FROM Report r WHERE r.post.type = 'ARTICLE'")
+    List<Report> findAllArticleReports();
+
+    @Query("SELECT r FROM Report r WHERE r.post.type = 'USERPOST'")
+    List<Report> findAllPostReports();
+
+    @Query("SELECT r FROM Report r WHERE r.post IS NULL")
+    List<Report> findAllCommentReports();
 }

--- a/src/main/java/com/nest/core/report_management_service/service/ReportService.java
+++ b/src/main/java/com/nest/core/report_management_service/service/ReportService.java
@@ -21,6 +21,7 @@ import com.nest.core.report_management_service.repository.ReportRepository;
 import com.nest.core.report_management_service.dto.GetPostReportsResponse;
 import com.nest.core.report_management_service.dto.ReportCommentRequest;
 import com.nest.core.report_management_service.dto.GetArticleReportsResponse;
+import com.nest.core.report_management_service.dto.GetCommentReportResponse;
 import com.nest.core.comment_management_service.repository.CommentRepository;
 
 import jakarta.transaction.Transactional;
@@ -122,6 +123,20 @@ public class ReportService {
                 .collect(Collectors.toList());
     }
 
+    public List<GetPostReportsResponse> getAllPostReports(Long userId) {
+
+        Member member = memberRepository.findById(userId)
+            .orElseThrow(() -> new MemberNotFoundException("Member not found"));
+
+        if (member.getRole() != MemberRole.ADMIN && member.getRole() != MemberRole.MODERATOR && member.getRole() != MemberRole.SUPER_ADMIN) {
+            throw new ReportDeleteFailException("Not authorized to view reports");
+        }
+
+        return reportRepository.findAllArticleReports().stream()
+                .map(GetPostReportsResponse::new)
+                .collect(Collectors.toList());
+    }
+
     public List<GetArticleReportsResponse> getArticleReports(Long postId, Long userId) {
 
         Member member = memberRepository.findById(userId)
@@ -134,6 +149,34 @@ public class ReportService {
 
         return reportRepository.findAllArticleReports(postId).stream()
                 .map(GetArticleReportsResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    public List<GetArticleReportsResponse> getAllArticleReports(Long userId) {
+
+        Member member = memberRepository.findById(userId)
+            .orElseThrow(() -> new MemberNotFoundException("Member not found"));
+
+        if (member.getRole() != MemberRole.ADMIN && member.getRole() != MemberRole.MODERATOR && member.getRole() != MemberRole.SUPER_ADMIN) {
+            throw new ReportDeleteFailException("Not authorized to view reports");
+        }
+
+        return reportRepository.findAllArticleReports().stream()
+                .map(GetArticleReportsResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    public List<GetCommentReportResponse> getAllCommentReports(Long userId) {
+
+        Member member = memberRepository.findById(userId)
+            .orElseThrow(() -> new MemberNotFoundException("Member not found"));
+
+        if (member.getRole() != MemberRole.ADMIN && member.getRole() != MemberRole.MODERATOR && member.getRole() != MemberRole.SUPER_ADMIN) {
+            throw new ReportDeleteFailException("Not authorized to view reports");
+        }
+
+        return reportRepository.findAllCommentReports().stream()
+                .map(GetCommentReportResponse::new)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
- Add 3 additional get methods to get all reports without specifying an ID (for post, comment, articles)
- Add 3 additional method overloads in report repository for getting all reports
- Add 3 additional method overloads in services to get reports without ID