### PR TITLE
[NEST-BE-40-41-43] Search API for article and posts that allows filtering and ordering

### DIFF
--- a/src/main/java/com/nest/core/auth_service/config/SecurityConfig.java
+++ b/src/main/java/com/nest/core/auth_service/config/SecurityConfig.java
@@ -141,6 +141,9 @@ public class SecurityConfig {
                         .requestMatchers(
                                 HttpMethod.POST, "/api/v1/notification/send/**"
                         ).hasAnyRole(MemberRole.ADMIN.name(), MemberRole.SUPER_ADMIN.name())
+                        // Search-Service
+                        .requestMatchers(HttpMethod.GET, "/api/v1/search/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 ).exceptionHandling(exceptionHandling -> exceptionHandling
                         .authenticationEntryPoint((request, response, authException) -> {

--- a/src/main/java/com/nest/core/search_service/README.md
+++ b/src/main/java/com/nest/core/search_service/README.md
@@ -1,1 +1,0 @@
-Not implemented Yet

--- a/src/main/java/com/nest/core/search_service/controller/SearchApiController.java
+++ b/src/main/java/com/nest/core/search_service/controller/SearchApiController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.nest.core.search_service.exception.SearchFailException;
 import com.nest.core.search_service.service.SearchService;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
@@ -21,14 +22,14 @@ public class SearchApiController {
 
     @GetMapping("/post")
     public ResponseEntity<?> searchPost(
-        @RequestParam("search_query") String searchQuery,
-        @RequestParam("topic") Optional<String> topic,
-        @RequestParam("tag") Optional<String> tag,
+        @RequestParam("search_query") Optional<String> searchQuery,
+        @RequestParam("topic") Optional<List<String>> topics,
+        @RequestParam("tag") Optional<List<String>> tags,
         @RequestParam("order_by") Optional<String> orderBy,
         @RequestParam("order") Optional<String> order
         ) {
         try {
-            return ResponseEntity.ok(searchService.searchPost(searchQuery, topic, tag, orderBy, order));
+            return ResponseEntity.ok(searchService.searchPost(searchQuery, topics, tags, orderBy, order));
 
         } catch(Exception e) {
             throw new SearchFailException("Failed to search: " + e.getMessage());
@@ -38,14 +39,14 @@ public class SearchApiController {
 
     @GetMapping("/article")
     public ResponseEntity<?> searchArticle(
-        @RequestParam("search_query") String searchQuery,
-        @RequestParam("topic") Optional<String> topic,
-        @RequestParam("tag") Optional<String> tag,
+        @RequestParam("search_query") Optional<String> searchQuery,
+        @RequestParam("topic") Optional<List<String>> topics,
+        @RequestParam("tag") Optional<List<String>> tags,
         @RequestParam("order_by") Optional<String> orderBy,
         @RequestParam("order") Optional<String> order
         ) {
         try {
-            return ResponseEntity.ok(searchService.searchArticle(searchQuery, topic, tag, orderBy, order));
+            return ResponseEntity.ok(searchService.searchArticle(searchQuery, topics, tags, orderBy, order));
 
         } catch(Exception e) {
             throw new SearchFailException("Failed to search: " + e.getMessage());

--- a/src/main/java/com/nest/core/search_service/controller/SearchApiController.java
+++ b/src/main/java/com/nest/core/search_service/controller/SearchApiController.java
@@ -1,0 +1,55 @@
+package com.nest.core.search_service.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nest.core.search_service.exception.SearchFailException;
+import com.nest.core.search_service.service.SearchService;
+
+import java.util.Optional;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/search")
+public class SearchApiController {
+    private final SearchService searchService;
+
+    @GetMapping("/post")
+    public ResponseEntity<?> searchPost(
+        @RequestParam("search_query") String searchQuery,
+        @RequestParam("topic") Optional<String> topic,
+        @RequestParam("tag") Optional<String> tag,
+        @RequestParam("order_by") Optional<String> orderBy,
+        @RequestParam("order") Optional<String> order
+        ) {
+        try {
+            return ResponseEntity.ok(searchService.searchPost(searchQuery, topic, tag, orderBy, order));
+
+        } catch(Exception e) {
+            throw new SearchFailException("Failed to search: " + e.getMessage());
+        }
+
+    }
+
+    @GetMapping("/article")
+    public ResponseEntity<?> searchArticle(
+        @RequestParam("search_query") String searchQuery,
+        @RequestParam("topic") Optional<String> topic,
+        @RequestParam("tag") Optional<String> tag,
+        @RequestParam("order_by") Optional<String> orderBy,
+        @RequestParam("order") Optional<String> order
+        ) {
+        try {
+            return ResponseEntity.ok(searchService.searchArticle(searchQuery, topic, tag, orderBy, order));
+
+        } catch(Exception e) {
+            throw new SearchFailException("Failed to search: " + e.getMessage());
+        }
+
+    }
+}

--- a/src/main/java/com/nest/core/search_service/dto/SearchResponse.java
+++ b/src/main/java/com/nest/core/search_service/dto/SearchResponse.java
@@ -1,5 +1,7 @@
 package com.nest.core.search_service.dto;
 
+import java.util.List;
+
 import com.nest.core.post_management_service.model.Post;
 
 import lombok.AllArgsConstructor;
@@ -9,8 +11,27 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SearchResponse {
     private Long id;
+    private String title;
+    private String creatorName;
+    private String content;
+    private String topic;
+    private List<String> tags;
+    private int shareCount;
+    private Long likesCount;
+    private Long viewCount;
+    private byte[] postImage;
+
 
     public SearchResponse(Post post) {
         this.id = post.getId();
+        this.title = post.getTitle();
+        this.creatorName = post.getMember().getUsername();
+        this.content = post.getContent();
+        this.likesCount = post.getLikesCount();
+        this.shareCount = post.getShareCount();
+        this.viewCount = post.getViewCount();
+        this.tags = post.getPostTags().stream().map(postTag -> postTag.getTag().getName()).toList();
+        this.topic = post.getTopic().getName();
+        this.postImage = post.getPostImages().stream().findFirst().map(postImage -> postImage.getImageData()).orElse(null);
     }
 }

--- a/src/main/java/com/nest/core/search_service/dto/SearchResponse.java
+++ b/src/main/java/com/nest/core/search_service/dto/SearchResponse.java
@@ -1,0 +1,16 @@
+package com.nest.core.search_service.dto;
+
+import com.nest.core.post_management_service.model.Post;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SearchResponse {
+    private Long id;
+
+    public SearchResponse(Post post) {
+        this.id = post.getId();
+    }
+}

--- a/src/main/java/com/nest/core/search_service/exception/BadRequestException.java
+++ b/src/main/java/com/nest/core/search_service/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.nest.core.search_service.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/nest/core/search_service/exception/SearchFailException.java
+++ b/src/main/java/com/nest/core/search_service/exception/SearchFailException.java
@@ -1,0 +1,8 @@
+package com.nest.core.search_service.exception;
+
+public class SearchFailException extends RuntimeException {
+    public SearchFailException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/nest/core/search_service/repository/SearchRepository.java
+++ b/src/main/java/com/nest/core/search_service/repository/SearchRepository.java
@@ -1,0 +1,8 @@
+package com.nest.core.search_service.repository;
+
+import com.nest.core.post_management_service.model.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface SearchRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
+}

--- a/src/main/java/com/nest/core/search_service/service/SearchService.java
+++ b/src/main/java/com/nest/core/search_service/service/SearchService.java
@@ -1,0 +1,92 @@
+package com.nest.core.search_service.service;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.coyote.BadRequestException;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Sort;
+
+import com.nest.core.post_management_service.model.Post;
+import com.nest.core.search_service.dto.SearchResponse;
+import com.nest.core.search_service.repository.SearchRepository;
+import com.nest.core.search_service.specification.PostSpecification;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class SearchService {
+    private final SearchRepository searchRepository;
+
+    public List<SearchResponse> searchPost(
+        String searchQuery,
+        Optional<String> topic,
+        Optional<String> tag,
+        Optional<String> orderBy,
+        Optional<String> order
+        ) throws BadRequestException, UnsupportedEncodingException {
+
+        if (!isValidRequest(orderBy, order)) {
+            throw new BadRequestException("Order by and order must be provided together or not at all");
+        }
+
+        Specification<Post> isPost = PostSpecification.isPost();
+        Specification<Post> hasTitle = PostSpecification.hasTitle(URLDecoder.decode(searchQuery, "UTF-8"));
+        Specification<Post> hasContent = PostSpecification.hasContent(URLDecoder.decode(searchQuery, "UTF-8"));
+
+        Specification<Post> spec = Specification.where(isPost).and(hasTitle.or(hasContent));
+
+        if (topic.isPresent()) spec = spec.and(PostSpecification.hasTopic(URLDecoder.decode(topic.get(), "UTF-8")));
+        if (tag.isPresent()) spec = spec.and(PostSpecification.hasTag(URLDecoder.decode(tag.get(), "UTF-8")));
+
+        Sort sort = PostSpecification.sortBy(orderBy.orElse("id"), order.orElse("ASC"));
+
+        return searchRepository.findAll(spec, sort).stream()
+                .map(SearchResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    public List<SearchResponse> searchArticle(
+        String searchQuery,
+        Optional<String> topic,
+        Optional<String> tag,
+        Optional<String> orderBy,
+        Optional<String> order
+        ) throws BadRequestException, UnsupportedEncodingException {
+
+        if (!isValidRequest(orderBy, order)) {
+            throw new BadRequestException("Order by and order must be provided together or not at all");
+        }
+
+        Specification<Post> isArticle = PostSpecification.isArticle();
+        Specification<Post> hasTitle = PostSpecification.hasTitle(URLDecoder.decode(searchQuery, "UTF-8"));
+        Specification<Post> hasContent = PostSpecification.hasContent(URLDecoder.decode(searchQuery, "UTF-8"));
+
+        Specification<Post> spec = Specification.where(isArticle).and(hasTitle.or(hasContent));
+
+        if (topic.isPresent()) spec = spec.and(PostSpecification.hasTopic(URLDecoder.decode(topic.get(), "UTF-8")));
+        if (tag.isPresent()) spec = spec.and(PostSpecification.hasTag(URLDecoder.decode(tag.get(), "UTF-8")));
+
+        Sort sort = PostSpecification.sortBy(orderBy.orElse("id"), order.orElse("ASC"));
+
+        return searchRepository.findAll(spec, sort).stream()
+                .map(SearchResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    private boolean isValidRequest(Optional<String> orderBy, Optional<String> order) {
+        if (orderBy.isPresent() && order.isPresent() || !orderBy.isPresent() && !order.isPresent()) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/nest/core/search_service/specification/PostSpecification.java
+++ b/src/main/java/com/nest/core/search_service/specification/PostSpecification.java
@@ -2,7 +2,6 @@ package com.nest.core.search_service.specification;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.web.client.HttpClientErrorException.BadRequest;
 
 import com.nest.core.post_management_service.model.Post;
 import com.nest.core.post_management_service.model.PostTag;

--- a/src/main/java/com/nest/core/search_service/specification/PostSpecification.java
+++ b/src/main/java/com/nest/core/search_service/specification/PostSpecification.java
@@ -1,0 +1,64 @@
+package com.nest.core.search_service.specification;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.web.client.HttpClientErrorException.BadRequest;
+
+import com.nest.core.post_management_service.model.Post;
+import com.nest.core.post_management_service.model.PostTag;
+import com.nest.core.search_service.exception.BadRequestException;
+import com.nest.core.tag_management_service.model.Tag;
+
+import jakarta.persistence.criteria.Join;
+
+public class PostSpecification {
+    public static Specification<Post> hasTag(String tag) {
+        return (root, query, criteriaBuilder) -> {
+            Join<Post, PostTag> postTagJoin = root.join("postTags");
+            Join<PostTag, Tag> tagJoin = postTagJoin.join("tag");
+            return criteriaBuilder.equal(tagJoin.get("name"), tag);
+        };
+    }
+
+    public static Specification<Post> hasTopic(String topic) {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.equal(root.get("topic").get("name"), topic);
+        };
+    }
+
+    public static Specification<Post> isArticle() {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.equal(root.get("type"), "ARTICLE");
+        };
+    }
+
+    public static Specification<Post> isPost() {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.equal(root.get("type"), "USERPOST");
+        };
+    }
+
+    public static Specification<Post> hasTitle(String title) {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.like(root.get("title"), "%" + title + "%");
+        };
+    }
+
+    public static Specification<Post> hasContent(String content) {
+        return (root, query, criteriaBuilder) -> {
+            return criteriaBuilder.like(root.get("content"), "%" + content + "%");
+        };
+    }
+
+    public static Sort sortBy(String orderBy, String order) throws BadRequestException{
+        if (order.equals("ASC")) {
+            return Sort.by(Sort.Direction.ASC, orderBy);
+
+        } else if (order.equals("DESC")) {
+            return Sort.by(Sort.Direction.DESC, orderBy);
+
+        } else {
+            throw new BadRequestException("Order must be either ASC or DESC");
+        }
+    }
+}


### PR DESCRIPTION
**Functionality**
- Search API is open to everyone (i.e. people not authenticated can use)
- Uses url parameters as the search queries
- Has separate endpoints for article and posts
- Search query finds any matching strings in the title and content of the post
- Search result returns only the IDs of posts and nothing else **(let me know if this should be changed)**

**Parameters**
- Parameters: search_query, topic, tag, order_by, order (ASC or DESC only)
- Can include multiple topics or tags for search
- Topics work by OR search (i.e. if Travel and Medical is selected, gets all post/articles that are under those topics)
- Tags work by AND search (i.e. if Tips and Fitness is selected, gets only post/articles that have BOTH tags)
- Default behavior without specifying order_by/order is id, ASC respectively
- order_by has to use the variable name in the Post model (i.e. likesCount, viewCount, shareCount)

**NOTE: I don't think posts have createdAt in the model, so I can't order by that**