### PR TITLE
[NEST-BE-44] Create API that CRUD tags

### DIFF
--- a/src/main/java/com/nest/core/tag_management_service/controller/TagApiController.java
+++ b/src/main/java/com/nest/core/tag_management_service/controller/TagApiController.java
@@ -1,0 +1,99 @@
+package com.nest.core.tag_management_service.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nest.core.auth_service.dto.CustomSecurityUserDetails;
+import com.nest.core.tag_management_service.dto.CreateTagRequest;
+import com.nest.core.tag_management_service.dto.EditTagRequest;
+import com.nest.core.tag_management_service.exception.CRUDFailException;
+import com.nest.core.tag_management_service.service.TagService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tag")
+public class TagApiController {
+    private final TagService tagService;
+
+    @GetMapping("/")
+    public ResponseEntity<?> getTags() {
+        try {
+            return ResponseEntity.ok(tagService.getAllTags());
+        } catch(Exception e) {
+            throw new CRUDFailException("Failed to get tags: " + e.getMessage());
+        }
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<?> createTag(@AuthenticationPrincipal UserDetails userDetails, @RequestBody CreateTagRequest tagRequest) {
+        if (userDetails instanceof CustomSecurityUserDetails) {
+            try {
+                String role = userDetails.getAuthorities().stream()
+                        .findFirst()
+                        .map(GrantedAuthority::getAuthority)
+                        .orElse("ROLE_USER");
+                return ResponseEntity.ok(tagService.createTag(tagRequest, role));
+
+            } catch (Exception e) {
+                throw new CRUDFailException("Failed to create tag: " + e.getMessage());
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+
+    @PutMapping("/update/{tagId}")
+    public ResponseEntity<?> updateTag(@AuthenticationPrincipal UserDetails userDetails,
+        @PathVariable Long tagId,
+        @RequestBody EditTagRequest editRequest) {
+
+        if (userDetails instanceof CustomSecurityUserDetails) {
+            try {
+                String role = userDetails.getAuthorities().stream()
+                        .findFirst()
+                        .map(GrantedAuthority::getAuthority)
+                        .orElse("ROLE_USER");
+                return ResponseEntity.ok(tagService.updateTag(tagId, editRequest, role));
+
+            } catch (Exception e) {
+                throw new CRUDFailException("Failed to update tag: " + e.getMessage());
+            }
+
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+
+    @DeleteMapping("/delete/{tagId}")
+    public ResponseEntity<?> deleteTag(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long tagId) {
+        if (userDetails instanceof CustomSecurityUserDetails) {
+            try {
+                String role = userDetails.getAuthorities().stream()
+                        .findFirst()
+                        .map(GrantedAuthority::getAuthority)
+                        .orElse("ROLE_USER");
+                tagService.deleteTag(tagId, role);
+                return ResponseEntity.ok("Tag deleted");
+
+            } catch (Exception e) {
+                throw new CRUDFailException("Failed to delete tag: " + e.getMessage());
+            }
+
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+}

--- a/src/main/java/com/nest/core/tag_management_service/dto/CreateTagRequest.java
+++ b/src/main/java/com/nest/core/tag_management_service/dto/CreateTagRequest.java
@@ -1,0 +1,18 @@
+package com.nest.core.tag_management_service.dto;
+
+import com.nest.core.tag_management_service.model.Tag;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateTagRequest {
+    private String name;
+
+    public Tag toEntity() {
+        return Tag.builder()
+                .name(this.name)
+                .build();
+    }
+}

--- a/src/main/java/com/nest/core/tag_management_service/dto/EditTagRequest.java
+++ b/src/main/java/com/nest/core/tag_management_service/dto/EditTagRequest.java
@@ -1,0 +1,10 @@
+package com.nest.core.tag_management_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EditTagRequest {
+    private String name;
+}

--- a/src/main/java/com/nest/core/tag_management_service/dto/GetTagResponse.java
+++ b/src/main/java/com/nest/core/tag_management_service/dto/GetTagResponse.java
@@ -1,0 +1,18 @@
+package com.nest.core.tag_management_service.dto;
+
+import com.nest.core.tag_management_service.model.Tag;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetTagResponse {
+    private Long id;
+    private String name;
+
+    public GetTagResponse(Tag tag) {
+        this.id = tag.getId();
+        this.name = tag.getName();
+    }
+}

--- a/src/main/java/com/nest/core/tag_management_service/exception/CRUDFailException.java
+++ b/src/main/java/com/nest/core/tag_management_service/exception/CRUDFailException.java
@@ -1,0 +1,8 @@
+package com.nest.core.tag_management_service.exception;
+
+public class CRUDFailException extends RuntimeException {
+    public CRUDFailException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/nest/core/tag_management_service/exception/TagNotFoundException.java
+++ b/src/main/java/com/nest/core/tag_management_service/exception/TagNotFoundException.java
@@ -1,0 +1,8 @@
+package com.nest.core.tag_management_service.exception;
+
+public class TagNotFoundException extends RuntimeException {
+    public TagNotFoundException(String message) {
+        super(message);
+    }
+    
+}

--- a/src/main/java/com/nest/core/tag_management_service/model/Tag.java
+++ b/src/main/java/com/nest/core/tag_management_service/model/Tag.java
@@ -1,18 +1,21 @@
 package com.nest.core.tag_management_service.model;
 
-import com.nest.core.post_management_service.model.Post;
 import com.nest.core.post_management_service.model.PostTag;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.HashSet;
 import java.util.Set;
 
 @Entity
+@Builder
 @Table(name="tag")
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class Tag {

--- a/src/main/java/com/nest/core/tag_management_service/service/TagService.java
+++ b/src/main/java/com/nest/core/tag_management_service/service/TagService.java
@@ -1,0 +1,66 @@
+package com.nest.core.tag_management_service.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.nest.core.tag_management_service.dto.CreateTagRequest;
+import com.nest.core.tag_management_service.dto.EditTagRequest;
+import com.nest.core.tag_management_service.dto.GetTagResponse;
+import com.nest.core.tag_management_service.exception.CRUDFailException;
+import com.nest.core.tag_management_service.exception.TagNotFoundException;
+import com.nest.core.tag_management_service.model.Tag;
+import com.nest.core.tag_management_service.repository.TagRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class TagService {
+    private final TagRepository tagRepository;
+
+    public List<GetTagResponse> getAllTags() {
+        return tagRepository.findAll().stream()
+                .map(GetTagResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public GetTagResponse createTag(CreateTagRequest tagRequest, String role) {
+        if (!role.equals("ROLE_ADMIN") && !role.equals("ROLE_SUPER_ADMIN")) {
+            throw new CRUDFailException("Not Authorized to create tag");
+        }
+        Tag newTag = tagRequest.toEntity();
+        tagRepository.save(newTag);
+        return new GetTagResponse(newTag);
+    }
+
+    @Transactional
+    public GetTagResponse updateTag(Long tagId, EditTagRequest editRequest, String role) {
+        if (!role.equals("ROLE_ADMIN") && !role.equals("ROLE_SUPER_ADMIN")) {
+            throw new CRUDFailException("Not Authorized to update tag");
+        }
+        Tag tag = tagRepository.findById(tagId)
+                .orElseThrow(() -> new TagNotFoundException("Tag not found"));
+
+        tag.setName(editRequest.getName());
+        tagRepository.save(tag);
+        return new GetTagResponse(tag);
+    }
+
+    @Transactional
+    public void deleteTag(Long tagId, String role) {
+        if (!role.equals("ROLE_ADMIN") && !role.equals("ROLE_SUPER_ADMIN")) {
+            throw new CRUDFailException("Not Authorized to delete tag");
+        }
+        Tag tag = tagRepository.findById(tagId)
+                .orElseThrow(() -> new TagNotFoundException("Tag not found"));
+
+        tagRepository.delete(tag);
+    }
+}


### PR DESCRIPTION
**Endpoints**
- /, /create, /update/{tagId}, /delete/{tagId}
- Only admins and super admins can create, update, and delete tags
- All logged in members can get tags 
- Read will return all tags in the database

I think everyone should be able to get tags, including not logged in users, but that requires configuring the security config file which I already did in the previous pull request for search (tickets 40, 41, 43) and I did not want to risk a merge conflict.