### PR TITLE
[NEST-BE-45] Create API that CRUD Topics

### DIFF
--- a/src/main/java/com/nest/core/topic_management_service/controller/TopicApiController.java
+++ b/src/main/java/com/nest/core/topic_management_service/controller/TopicApiController.java
@@ -1,0 +1,93 @@
+package com.nest.core.topic_management_service.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nest.core.auth_service.dto.CustomSecurityUserDetails;
+import com.nest.core.topic_management_service.dto.CreateTopicRequest;
+import com.nest.core.topic_management_service.dto.EditTopicRequest;
+import com.nest.core.topic_management_service.exceptions.TopicCRUDFailException;
+import com.nest.core.topic_management_service.service.TopicService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/topic")
+public class TopicApiController {
+    private final TopicService topicService;
+
+    @GetMapping("/")
+    public ResponseEntity<?> getTopics() {
+        try {
+            return ResponseEntity.ok(topicService.getAllTopics());
+        } catch(Exception e) {
+            throw new TopicCRUDFailException("Failed to get topics: " + e.getMessage());
+        }
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<?> createTopic(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody CreateTopicRequest createTopicRequest) {
+
+        if (userDetails instanceof CustomSecurityUserDetails) {
+            String role = userDetails.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .findFirst()
+                    .orElse(null);
+            return ResponseEntity.ok(topicService.createTopic(createTopicRequest, role));
+
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+
+    @PutMapping("/update/{topicId}")
+    public ResponseEntity<?> updateTopic(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @PathVariable Long topicId,
+        @RequestBody EditTopicRequest editTopicRequest) {
+
+        if (userDetails instanceof CustomSecurityUserDetails) {
+            String role = userDetails.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .findFirst()
+                    .orElse(null);
+            return ResponseEntity.ok(topicService.updateTopic(topicId, editTopicRequest, role));
+
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+
+    }
+
+    @DeleteMapping("/delete/{topicId}")
+    public ResponseEntity<?> deleteTopic(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @PathVariable Long topicId) {
+
+        if (userDetails instanceof CustomSecurityUserDetails) {
+            String role = userDetails.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .findFirst()
+                    .orElse(null);
+            topicService.deleteTopic(topicId, role);
+            return ResponseEntity.ok("Topic deleted");
+
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
+}

--- a/src/main/java/com/nest/core/topic_management_service/dto/CreateTopicRequest.java
+++ b/src/main/java/com/nest/core/topic_management_service/dto/CreateTopicRequest.java
@@ -1,0 +1,20 @@
+package com.nest.core.topic_management_service.dto;
+
+import com.nest.core.topic_management_service.model.Topic;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateTopicRequest {
+    private String name;
+    private String description;
+
+    public Topic toEntity() {
+        return Topic.builder()
+                .name(this.name)
+                .description(this.description)
+                .build();
+    }
+}

--- a/src/main/java/com/nest/core/topic_management_service/dto/EditTopicRequest.java
+++ b/src/main/java/com/nest/core/topic_management_service/dto/EditTopicRequest.java
@@ -1,0 +1,11 @@
+package com.nest.core.topic_management_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EditTopicRequest {
+    private String name;
+    private String description;
+}

--- a/src/main/java/com/nest/core/topic_management_service/dto/GetTopicResponse.java
+++ b/src/main/java/com/nest/core/topic_management_service/dto/GetTopicResponse.java
@@ -1,0 +1,20 @@
+package com.nest.core.topic_management_service.dto;
+
+import com.nest.core.topic_management_service.model.Topic;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetTopicResponse {
+    private Long id;
+    private String name;
+    private String description;
+
+    public GetTopicResponse(Topic topic) {
+        this.id = topic.getId();
+        this.name = topic.getName();
+        this.description = topic.getDescription();
+    }
+}

--- a/src/main/java/com/nest/core/topic_management_service/exceptions/TopicCRUDFailException.java
+++ b/src/main/java/com/nest/core/topic_management_service/exceptions/TopicCRUDFailException.java
@@ -1,0 +1,7 @@
+package com.nest.core.topic_management_service.exceptions;
+
+public class TopicCRUDFailException extends RuntimeException {
+    public TopicCRUDFailException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nest/core/topic_management_service/exceptions/TopicNotFoundException.java
+++ b/src/main/java/com/nest/core/topic_management_service/exceptions/TopicNotFoundException.java
@@ -1,0 +1,8 @@
+package com.nest.core.topic_management_service.exceptions;
+
+public class TopicNotFoundException extends RuntimeException {
+    public TopicNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/nest/core/topic_management_service/model/Topic.java
+++ b/src/main/java/com/nest/core/topic_management_service/model/Topic.java
@@ -3,12 +3,20 @@ package com.nest.core.topic_management_service.model;
 
 import com.nest.core.post_management_service.model.Post;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.Set;
 
 @Entity
+@Builder
 @Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 @Table(name="topic")
 public class Topic {
     @Id

--- a/src/main/java/com/nest/core/topic_management_service/service/TopicService.java
+++ b/src/main/java/com/nest/core/topic_management_service/service/TopicService.java
@@ -1,0 +1,67 @@
+package com.nest.core.topic_management_service.service;
+
+import com.nest.core.topic_management_service.repository.TopicRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.nest.core.topic_management_service.dto.CreateTopicRequest;
+import com.nest.core.topic_management_service.dto.EditTopicRequest;
+import com.nest.core.topic_management_service.dto.GetTopicResponse;
+import com.nest.core.topic_management_service.exceptions.TopicCRUDFailException;
+import com.nest.core.topic_management_service.exceptions.TopicNotFoundException;
+import com.nest.core.topic_management_service.model.Topic;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class TopicService {
+    private final TopicRepository topicRepository;
+
+    public List<GetTopicResponse> getAllTopics() {
+        return topicRepository.findAll().stream()
+                .map(GetTopicResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public GetTopicResponse createTopic(CreateTopicRequest createRequest, String role) {
+        if (!role.equals("ROLE_ADMIN") && !role.equals("ROLE_SUPER_ADMIN")) {
+            throw new TopicCRUDFailException("Not Authorized to create topic");
+        }
+        Topic newTopic = createRequest.toEntity();
+        topicRepository.save(newTopic);
+        return new GetTopicResponse(newTopic);
+    }
+
+    @Transactional
+    public GetTopicResponse updateTopic(Long topicId, EditTopicRequest editRequest, String role) {
+        if (!role.equals("ROLE_ADMIN") && !role.equals("ROLE_SUPER_ADMIN")) {
+            throw new TopicCRUDFailException("Not Authorized to update topic");
+        }
+        Topic topic = topicRepository.findById(topicId)
+                .orElseThrow(() -> new TopicNotFoundException("Topic not found"));
+
+        topic.setName(editRequest.getName());
+        topic.setDescription(editRequest.getDescription());
+        topicRepository.save(topic);
+        return new GetTopicResponse(topic);
+    }
+
+    @Transactional
+    public void deleteTopic(Long topicId, String role) {
+        if (!role.equals("ROLE_ADMIN") && !role.equals("ROLE_SUPER_ADMIN")) {
+            throw new TopicCRUDFailException("Not Authorized to delete topic");
+        }
+        Topic topic = topicRepository.findById(topicId)
+                .orElseThrow(() -> new TopicNotFoundException("Topic not found"));
+        topicRepository.delete(topic);
+    }
+}


### PR DESCRIPTION
**Endpoints**
- /, /create, /update/{topicId}, /delete/{topicId}
- Only admins and super admins can create, update, delete topics
- All logged in members can get topics
- Read will return all topics in the database
- Updating the topic requires both name and description of the field again, let me know if this should be changed so if one of the fields is missing update doesn't do anything to it

Like mentioned in ticket 44, I think everyone including not-logged in users should be able to get all topics, but again requires changing security config file that may cause merge conflict.