### PR TITLE
[NEST-BE-48] Implement API for forget password (forgot password sends email to reset)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/nest/core/auth_service/config/SecurityConfig.java
+++ b/src/main/java/com/nest/core/auth_service/config/SecurityConfig.java
@@ -161,7 +161,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/tag")
                         .permitAll()
                         // Password reset service
-                        .requestMatchers("/api/v1/password/reset")
+                        .requestMatchers("/api/v1/password/reset/*")
                         .permitAll()
                         .requestMatchers("/api/v1/password/forgot")
                         .permitAll()

--- a/src/main/java/com/nest/core/auth_service/config/SecurityConfig.java
+++ b/src/main/java/com/nest/core/auth_service/config/SecurityConfig.java
@@ -160,6 +160,11 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/tag")
                         .permitAll()
+                        // Password reset service
+                        .requestMatchers("/api/v1/password/reset")
+                        .permitAll()
+                        .requestMatchers("/api/v1/password/forgot")
+                        .permitAll()
                         .anyRequest().authenticated()
                 ).exceptionHandling(exceptionHandling -> exceptionHandling
                         .authenticationEntryPoint((request, response, authException) -> {

--- a/src/main/java/com/nest/core/auth_service/security/JWTUtil.java
+++ b/src/main/java/com/nest/core/auth_service/security/JWTUtil.java
@@ -10,6 +10,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -85,18 +86,19 @@ public class JWTUtil {
                 .signWith(secretKey)
                 .compact();
 
+        String resetUID = UUID.randomUUID().toString();
+
         redisTemplate.opsForValue().set(
-                email,
+                resetUID,
                 resetToken,
                 expiredMs,
                 TimeUnit.MILLISECONDS
         );
 
-        return resetToken;
+        return resetUID;
     }
 
-    public void deleteTokens(String email) {
-        // TODO: Figure out why this thing won't get deleted
-        redisTemplate.delete(email);
+    public String getResetToken(String resetUID) {
+        return (String) redisTemplate.opsForValue().getAndDelete(resetUID);
     }
 }

--- a/src/main/java/com/nest/core/auth_service/security/JWTUtil.java
+++ b/src/main/java/com/nest/core/auth_service/security/JWTUtil.java
@@ -73,4 +73,30 @@ public class JWTUtil {
 
         return refreshToken;
     }
+
+    public String createResetToken(String email, Long expiredMs) {
+        Date now = new Date(System.currentTimeMillis());
+        Date expiration = new Date(System.currentTimeMillis() + expiredMs);
+
+        String resetToken = Jwts.builder()
+                .claim("email", email)
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(secretKey)
+                .compact();
+
+        redisTemplate.opsForValue().set(
+                email,
+                resetToken,
+                expiredMs,
+                TimeUnit.MILLISECONDS
+        );
+
+        return resetToken;
+    }
+
+    public void deleteTokens(String email) {
+        // TODO: Figure out why this thing won't get deleted
+        redisTemplate.delete(email);
+    }
 }

--- a/src/main/java/com/nest/core/password_management_service/controller/PasswordApiController.java
+++ b/src/main/java/com/nest/core/password_management_service/controller/PasswordApiController.java
@@ -37,8 +37,8 @@ public class PasswordApiController {
 
     @PostMapping("/forgot")
     public ResponseEntity<?> forgotPassword(@RequestBody SendResetCodeRequest codeRequest, HttpServletRequest request) {
-        String resetToken = passwordService.generateResetToken(codeRequest);
-        mailService.sendResetToken(codeRequest.getEmail(), request.getHeader("Origin"), resetToken);
+        String resetUID = passwordService.generateResetToken(codeRequest);
+        mailService.sendResetUID(codeRequest.getEmail(), request.getHeader("Origin"), resetUID);
         return ResponseEntity.ok("Reset token successfully sent to " + codeRequest.getEmail());
     }
 

--- a/src/main/java/com/nest/core/password_management_service/controller/PasswordApiController.java
+++ b/src/main/java/com/nest/core/password_management_service/controller/PasswordApiController.java
@@ -32,7 +32,7 @@ public class PasswordApiController {
         }
     }
 
-    @PutMapping("/forgot")
+    @PostMapping("/forgot")
     public ResponseEntity<?> forgotPassword(@RequestBody SendResetCodeRequest codeRequest) {
         passwordService.sendEmail(codeRequest);
         return ResponseEntity.ok("Not implemented yet");

--- a/src/main/java/com/nest/core/password_management_service/controller/PasswordApiController.java
+++ b/src/main/java/com/nest/core/password_management_service/controller/PasswordApiController.java
@@ -42,9 +42,9 @@ public class PasswordApiController {
         return ResponseEntity.ok("Reset token successfully sent to " + codeRequest.getEmail());
     }
 
-    @PutMapping("/reset/{token}")
-    public ResponseEntity<?> resetPassword(@PathVariable String token, @RequestBody ResetPasswordRequest resetRequest) {
-        passwordService.resetPassword(resetRequest, token);
+    @PutMapping("/reset/{resetUID}")
+    public ResponseEntity<?> resetPassword(@PathVariable String resetUID, @RequestBody ResetPasswordRequest resetRequest) {
+        passwordService.resetPassword(resetRequest, resetUID);
         return ResponseEntity.ok("Password successfully reset");
     }
 }

--- a/src/main/java/com/nest/core/password_management_service/controller/PasswordApiController.java
+++ b/src/main/java/com/nest/core/password_management_service/controller/PasswordApiController.java
@@ -1,0 +1,46 @@
+package com.nest.core.password_management_service.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import com.nest.core.auth_service.dto.CustomSecurityUserDetails;
+import com.nest.core.password_management_service.dto.ChangePasswordRequest;
+import com.nest.core.password_management_service.dto.ResetPasswordRequest;
+import com.nest.core.password_management_service.dto.SendResetCodeRequest;
+import com.nest.core.password_management_service.service.PasswordService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/password")
+@Slf4j
+public class PasswordApiController {
+    private final PasswordService passwordService;
+
+    @PutMapping("/change")
+    public ResponseEntity<?> changePassword(@AuthenticationPrincipal UserDetails userDetails, @RequestBody ChangePasswordRequest changeRequest) {
+
+        if (userDetails instanceof CustomSecurityUserDetails customUser) {
+            passwordService.changePassword(customUser.getUserId(), changeRequest);
+            return ResponseEntity.ok("Password changed");
+        } else {
+            return ResponseEntity.badRequest().body("Cannot change password of unauthenticated user");
+        }
+    }
+
+    @PutMapping("/forgot")
+    public ResponseEntity<?> forgotPassword(@RequestBody SendResetCodeRequest codeRequest) {
+        passwordService.sendEmail(codeRequest);
+        return ResponseEntity.ok("Not implemented yet");
+    }
+
+    @PutMapping("/reset")
+    public ResponseEntity<?> resetPassword(@RequestBody ResetPasswordRequest resetRequest) {
+        passwordService.resetPassword(resetRequest);
+        return ResponseEntity.ok("Not implemented yet");
+    }
+}

--- a/src/main/java/com/nest/core/password_management_service/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/nest/core/password_management_service/dto/ChangePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.nest.core.password_management_service.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChangePasswordRequest {
+    private String oldPassword;
+    private String newPassword;
+}

--- a/src/main/java/com/nest/core/password_management_service/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/nest/core/password_management_service/dto/ResetPasswordRequest.java
@@ -8,7 +8,5 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class ResetPasswordRequest {
-    private String email;
-    private String code;
     private String newPassword;
 }

--- a/src/main/java/com/nest/core/password_management_service/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/nest/core/password_management_service/dto/ResetPasswordRequest.java
@@ -1,0 +1,14 @@
+package com.nest.core.password_management_service.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ResetPasswordRequest {
+    private String email;
+    private String code;
+    private String newPassword;
+}

--- a/src/main/java/com/nest/core/password_management_service/dto/SendResetCodeRequest.java
+++ b/src/main/java/com/nest/core/password_management_service/dto/SendResetCodeRequest.java
@@ -1,0 +1,12 @@
+package com.nest.core.password_management_service.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SendResetCodeRequest {
+    private String email;
+}

--- a/src/main/java/com/nest/core/password_management_service/exception/EmailNotFoundException.java
+++ b/src/main/java/com/nest/core/password_management_service/exception/EmailNotFoundException.java
@@ -1,0 +1,8 @@
+package com.nest.core.password_management_service.exception;
+
+public class EmailNotFoundException extends RuntimeException {
+    public EmailNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/nest/core/password_management_service/exception/InvalidNewPasswordException.java
+++ b/src/main/java/com/nest/core/password_management_service/exception/InvalidNewPasswordException.java
@@ -1,0 +1,8 @@
+package com.nest.core.password_management_service.exception;
+
+public class InvalidNewPasswordException extends RuntimeException {
+    public InvalidNewPasswordException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/nest/core/password_management_service/exception/InvalidOldPasswordException.java
+++ b/src/main/java/com/nest/core/password_management_service/exception/InvalidOldPasswordException.java
@@ -1,0 +1,8 @@
+package com.nest.core.password_management_service.exception;
+
+public class InvalidOldPasswordException extends RuntimeException {
+    public InvalidOldPasswordException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/nest/core/password_management_service/exception/InvalidResetCodeException.java
+++ b/src/main/java/com/nest/core/password_management_service/exception/InvalidResetCodeException.java
@@ -1,0 +1,8 @@
+package com.nest.core.password_management_service.exception;
+
+public class InvalidResetCodeException extends RuntimeException {
+    public InvalidResetCodeException(String message) {
+        super(message);
+    }
+    
+}

--- a/src/main/java/com/nest/core/password_management_service/service/MailService.java
+++ b/src/main/java/com/nest/core/password_management_service/service/MailService.java
@@ -23,7 +23,7 @@ public class MailService {
     // Frontend can maybe adjust what the email could look like to match with the rest of the site
     private static final String emailStart = "NEST - Password Reset Request\n\nHello, someone has requested a password reset for your account.\n\n";
     private static final String emailCode = "Click on this link to reset your password: ";
-    private static final String emailEnd = "\n\nThis code will expire in 5 minuntes\n\nIf you did not request this, please ignore this email.\n\nNEST Team";
+    private static final String emailEnd = "\n\nThis code will expire in 10 minuntes\n\nIf you did not request this, please ignore this email.\n\nNEST Team";
 
     public void sendResetToken(String email, String domain, String resetToken) {
 

--- a/src/main/java/com/nest/core/password_management_service/service/MailService.java
+++ b/src/main/java/com/nest/core/password_management_service/service/MailService.java
@@ -1,0 +1,39 @@
+package com.nest.core.password_management_service.service;
+
+import org.springframework.stereotype.Service;
+
+import com.nest.core.member_management_service.repository.MemberRepository;
+import com.nest.core.password_management_service.exception.EmailNotFoundException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.*;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MailService {
+
+    @Autowired
+    private JavaMailSender emailSender;
+
+    // Frontend can maybe adjust what the email could look like to match with the rest of the site
+    private static final String emailStart = "NEST - Password Reset Request\n\nHello, someone has requested a password reset for your account.\n\n";
+    private static final String emailCode = "Click on this link to reset your password: ";
+    private static final String emailEnd = "\n\nThis code will expire in 5 minuntes\n\nIf you did not request this, please ignore this email.\n\nNEST Team";
+
+    public void sendResetToken(String email, String domain, String resetToken) {
+
+        SimpleMailMessage mail = new SimpleMailMessage();
+        mail.setFrom("noreply@nest.com");
+        mail.setTo(email);
+        mail.setSubject("NEST - Password Reset Request");
+        mail.setText(emailStart + emailCode + domain + "/" + resetToken + emailEnd);
+        emailSender.send(mail);
+
+        log.info("Reset token sent to {}", email);
+    }
+}

--- a/src/main/java/com/nest/core/password_management_service/service/MailService.java
+++ b/src/main/java/com/nest/core/password_management_service/service/MailService.java
@@ -25,13 +25,13 @@ public class MailService {
     private static final String emailCode = "Click on this link to reset your password: ";
     private static final String emailEnd = "\n\nThis code will expire in 10 minuntes\n\nIf you did not request this, please ignore this email.\n\nNEST Team";
 
-    public void sendResetToken(String email, String domain, String resetToken) {
+    public void sendResetUID(String email, String domain, String resetUID) {
 
         SimpleMailMessage mail = new SimpleMailMessage();
         mail.setFrom("noreply@nest.com");
         mail.setTo(email);
         mail.setSubject("NEST - Password Reset Request");
-        mail.setText(emailStart + emailCode + domain + "/" + resetToken + emailEnd);
+        mail.setText(emailStart + emailCode + domain + "/" + resetUID + emailEnd);
         emailSender.send(mail);
 
         log.info("Reset token sent to {}", email);

--- a/src/main/java/com/nest/core/password_management_service/service/PasswordService.java
+++ b/src/main/java/com/nest/core/password_management_service/service/PasswordService.java
@@ -3,14 +3,17 @@ package com.nest.core.password_management_service.service;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.nest.core.auth_service.security.JWTUtil;
 import com.nest.core.member_management_service.exception.MemberNotFoundException;
 import com.nest.core.member_management_service.model.Member;
 import com.nest.core.member_management_service.repository.MemberRepository;
 import com.nest.core.password_management_service.dto.ChangePasswordRequest;
 import com.nest.core.password_management_service.dto.ResetPasswordRequest;
 import com.nest.core.password_management_service.dto.SendResetCodeRequest;
+import com.nest.core.password_management_service.exception.EmailNotFoundException;
 import com.nest.core.password_management_service.exception.InvalidNewPasswordException;
 import com.nest.core.password_management_service.exception.InvalidOldPasswordException;
+import com.nest.core.password_management_service.exception.InvalidResetCodeException;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class PasswordService {
+    private final JWTUtil jwtUtil;
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
@@ -45,12 +49,37 @@ public class PasswordService {
         }
     }
 
-    public void sendEmail(SendResetCodeRequest codeRequest) {
-        // TODO: Find a way to send an email to the email of the request
+    public String generateResetToken(SendResetCodeRequest codeRequest) {
+        Member member = memberRepository.findByEmail(codeRequest.getEmail());
+        if (member == null) {
+            throw new EmailNotFoundException("Email not associated with an account");
+        }
+        return jwtUtil.createResetToken(codeRequest.getEmail(), 1000 * 60 * 10L);
     }
 
-    public void resetPassword(ResetPasswordRequest resetRequest) {
-        // TODO: Find a way to generate a code and verify the code is correct
+    public void resetPassword(ResetPasswordRequest resetRequest, String token) {
+        if (jwtUtil.isExpired(token)) {
+            throw new InvalidResetCodeException("Code is either expired or invalid");
+        }
+        String email = jwtUtil.getEmail(token);
+        Member member = memberRepository.findByEmail(email);
+        if (member == null) {
+            throw new MemberNotFoundException("Associated reset token email could not be found");
+        }
+        if (bCryptPasswordEncoder.matches(resetRequest.getNewPassword(), member.getPassword())) {
+            throw new InvalidNewPasswordException("New password cannot be the same as the old password");
+        }
+
+        member.setPassword(bCryptPasswordEncoder.encode(resetRequest.getNewPassword()));
+
+        try {
+            memberRepository.save(member);
+            jwtUtil.deleteTokens(token);
+
+        } catch (Exception e) {
+            log.warn("Error updating password: {}", e.getMessage());
+            throw new RuntimeException("Unexpected error occurred while updating password");
+        }
     }
 
 }

--- a/src/main/java/com/nest/core/password_management_service/service/PasswordService.java
+++ b/src/main/java/com/nest/core/password_management_service/service/PasswordService.java
@@ -57,8 +57,9 @@ public class PasswordService {
         return jwtUtil.createResetToken(codeRequest.getEmail(), 1000 * 60 * 10L);
     }
 
-    public void resetPassword(ResetPasswordRequest resetRequest, String token) {
-        if (jwtUtil.isExpired(token)) {
+    public void resetPassword(ResetPasswordRequest resetRequest, String resetUID) {
+        String token = jwtUtil.getResetToken(resetUID);
+        if (token == null || jwtUtil.isExpired(token)) {
             throw new InvalidResetCodeException("Code is either expired or invalid");
         }
         String email = jwtUtil.getEmail(token);
@@ -74,7 +75,6 @@ public class PasswordService {
 
         try {
             memberRepository.save(member);
-            jwtUtil.deleteTokens(token);
 
         } catch (Exception e) {
             log.warn("Error updating password: {}", e.getMessage());

--- a/src/main/java/com/nest/core/password_management_service/service/PasswordService.java
+++ b/src/main/java/com/nest/core/password_management_service/service/PasswordService.java
@@ -1,0 +1,56 @@
+package com.nest.core.password_management_service.service;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.nest.core.member_management_service.exception.MemberNotFoundException;
+import com.nest.core.member_management_service.model.Member;
+import com.nest.core.member_management_service.repository.MemberRepository;
+import com.nest.core.password_management_service.dto.ChangePasswordRequest;
+import com.nest.core.password_management_service.dto.ResetPasswordRequest;
+import com.nest.core.password_management_service.dto.SendResetCodeRequest;
+import com.nest.core.password_management_service.exception.InvalidNewPasswordException;
+import com.nest.core.password_management_service.exception.InvalidOldPasswordException;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class PasswordService {
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public void changePassword(Long userId, ChangePasswordRequest changeRequest) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new MemberNotFoundException("User not found"));
+
+        if (!bCryptPasswordEncoder.matches(changeRequest.getOldPassword(), member.getPassword())) {
+            throw new InvalidOldPasswordException("Old password does not match");
+        }
+        if (bCryptPasswordEncoder.matches(changeRequest.getNewPassword(), member.getPassword())) {
+            throw new InvalidNewPasswordException("New password cannot be the same as the old password");
+        }
+
+        member.setPassword(bCryptPasswordEncoder.encode(changeRequest.getNewPassword()));
+
+        try {
+            memberRepository.save(member);
+        } catch (Exception e) {
+            log.warn("Error updating password: {}", e.getMessage());
+            throw new RuntimeException("Unexpected error occurred while updating password");
+        }
+    }
+
+    public void sendEmail(SendResetCodeRequest codeRequest) {
+        // TODO: Find a way to send an email to the email of the request
+    }
+
+    public void resetPassword(ResetPasswordRequest resetRequest) {
+        // TODO: Find a way to generate a code and verify the code is correct
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,10 @@ spring.redis.data.host=${REDIS_HOST}
 spring.redis.data.port=${REDIS_PORT}
 
 spring.jwt.secret=${JWT_SECRET}
+
+spring.mail.host=${MAIL_HOST}
+spring.mail.port=${MAIL_PORT}
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true


### PR DESCRIPTION
- Added dependency for 'org.springframework.boot:spring-boot-starter-mail'
- **Checkover if i messed up the dependencies, I got some build warnings after including the dependency even though I did not even touch the code**

**Includes** 
- /api/v1/password/change (change password for logged in user)
- /api/v1/password/forgot (sends email to the inputted email)
- /api/v1/password/reset (resets the password after user clicks on the link)

**Notes**
- The link right now uses request.getHeader("Origin"), this is probably going to need to change when frontend makes the page for reseting the password
- Email looks very barebones right now, could maybe style with html but that depends on frontend decision
- Also email uses my throw-away google account, the receiver is going to see it's an email from my throw away
- Right now if a user tries to change their password to their old password in the reset link, it's going to immediately kill the token while telling the user they failed because its the same as their old password *(Does this even matter? Feature????????)*