### PR TITLE
[NEST-BE-49-50-51] Most Active Users and Posts/Articles

### DIFF
--- a/src/main/java/com/nest/core/member_management_service/controller/MemberApiController.java
+++ b/src/main/java/com/nest/core/member_management_service/controller/MemberApiController.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -90,5 +91,23 @@ public class MemberApiController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
         }
 
+    }
+
+    @GetMapping("/mostActive")
+    public ResponseEntity<?> getMostActiveUsers(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestParam("count") Optional<Integer> count,
+        @RequestParam("region") Optional<String> region
+    ) {
+        if (userDetails instanceof CustomSecurityUserDetails) {
+            String userRole = userDetails.getAuthorities().stream()
+                    .findFirst()
+                    .map(GrantedAuthority::getAuthority)
+                    .orElse("ROLE_USER");
+            return ResponseEntity.ok(memberService.getMostActiveUsers(count, region, userRole));
+
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
     }
 }

--- a/src/main/java/com/nest/core/member_management_service/exception/GetActivePermissionException.java
+++ b/src/main/java/com/nest/core/member_management_service/exception/GetActivePermissionException.java
@@ -1,0 +1,8 @@
+package com.nest.core.member_management_service.exception;
+
+public class GetActivePermissionException extends RuntimeException {
+    public GetActivePermissionException(String message) {
+        super(message);
+    }
+    
+}

--- a/src/main/java/com/nest/core/member_management_service/repository/MemberRepository.java
+++ b/src/main/java/com/nest/core/member_management_service/repository/MemberRepository.java
@@ -1,9 +1,16 @@
 package com.nest.core.member_management_service.repository;
 
 import com.nest.core.member_management_service.model.Member;
+
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     Member findByEmail(String email);
+
+    @Query("SELECT m FROM Member m WHERE m.region = :region")
+    List<Member> findAllByRegion(String region);
 }

--- a/src/main/java/com/nest/core/post_management_service/controller/ArticleApiController.java
+++ b/src/main/java/com/nest/core/post_management_service/controller/ArticleApiController.java
@@ -14,6 +14,9 @@ import com.nest.core.post_management_service.exception.RemoveBookmarkFailExcepti
 import com.nest.core.post_management_service.model.Post;
 import com.nest.core.post_management_service.service.ArticleService;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
 import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -100,4 +103,20 @@ public class ArticleApiController {
         return ResponseEntity.ok(articleService.getArticlesByUserId(userId));
     }
 
+    @GetMapping("/mostActive")
+    public ResponseEntity<?> getMostActive(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestParam("count") Optional<Integer> count,
+        @RequestParam("region") Optional<String> region
+    ) {
+        if (userDetails instanceof CustomSecurityUserDetails) {
+            String userRole = userDetails.getAuthorities().stream()
+                    .findFirst()
+                    .map(GrantedAuthority::getAuthority)
+                    .orElse("ROLE_USER");
+            return ResponseEntity.ok(articleService.getMostActiveArticles(count, region, userRole));
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
 }

--- a/src/main/java/com/nest/core/post_management_service/controller/PostApiController.java
+++ b/src/main/java/com/nest/core/post_management_service/controller/PostApiController.java
@@ -6,6 +6,9 @@ import com.nest.core.post_management_service.dto.EditPostRequest;
 import com.nest.core.post_management_service.exception.*;
 import com.nest.core.post_management_service.service.PostService;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.GrantedAuthority;
@@ -88,4 +91,20 @@ public class PostApiController {
         return ResponseEntity.ok(postService.getPostsByUserId(userId));
     }
 
+    @GetMapping("/mostActive")
+    public ResponseEntity<?> getMostActive(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestParam("count") Optional<Integer> count,
+        @RequestParam("region") Optional<String> region
+    ) {
+        if (userDetails instanceof CustomSecurityUserDetails) {
+            String userRole = userDetails.getAuthorities().stream()
+                    .findFirst()
+                    .map(GrantedAuthority::getAuthority)
+                    .orElse("ROLE_USER");
+            return ResponseEntity.ok(postService.getMostActivePost(count, region, userRole));
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid user details");
+        }
+    }
 }

--- a/src/main/java/com/nest/core/post_management_service/exception/GetActivePermissionException.java
+++ b/src/main/java/com/nest/core/post_management_service/exception/GetActivePermissionException.java
@@ -1,0 +1,7 @@
+package com.nest.core.post_management_service.exception;
+
+public class GetActivePermissionException extends RuntimeException {
+    public GetActivePermissionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nest/core/post_management_service/service/ArticleService.java
+++ b/src/main/java/com/nest/core/post_management_service/service/ArticleService.java
@@ -178,36 +178,19 @@ public class ArticleService {
         if (!userRole.equals("ROLE_ADMIN") && !userRole.equals("ROLE_SUPER_ADMIN")) {
             throw new GetActivePermissionException("Not authorized to get most active articles");
         }
-        int limit = count.orElse(10);
-        Specification<Post> articleType = PostSpecification.isArticle();
-        if (region.isPresent()) {
-            Specification<Post> regionSpec = PostSpecification.fromRegion(region.get());
-            Specification<Post> spec = articleType.and(regionSpec);
+        Specification<Post> spec = PostSpecification.isArticle();
+        if (region.isPresent()) spec = spec.and(PostSpecification.fromRegion(region.get()));
 
-            List<Post> articles = searchRepository.findAll(spec);
-            articles.sort(
-                Comparator.comparingInt((Post post) -> post.getComments().size())
-                        .thenComparingLong(Post::getLikesCount)
-                        .thenComparingLong(Post::getViewCount)
-                        .reversed()
-            );
-            return articles.stream()
-                    .map(GetArticleResponse::new)
-                    .limit(limit)
-                    .collect(Collectors.toList());
-
-        } else {
-            List<Post> articles = searchRepository.findAll(articleType);
-            articles.sort(
-                Comparator.comparingInt((Post post) -> post.getComments().size())
-                        .thenComparingLong(Post::getLikesCount)
-                        .thenComparingLong(Post::getViewCount)
-                        .reversed()
-            );
-            return articles.stream()
-                    .map(GetArticleResponse::new)
-                    .limit(limit)
-                    .collect(Collectors.toList());
-        }
+        List<Post> articles = searchRepository.findAll(spec);
+        articles.sort(
+            Comparator.comparingInt((Post post) -> post.getComments().size())
+                    .thenComparingLong(Post::getLikesCount)
+                    .thenComparingLong(Post::getViewCount)
+                    .reversed()
+        );
+        return articles.stream()
+                .map(GetArticleResponse::new)
+                .limit(count.orElse(10))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/nest/core/post_management_service/service/ArticleService.java
+++ b/src/main/java/com/nest/core/post_management_service/service/ArticleService.java
@@ -13,11 +13,14 @@ import com.nest.core.post_management_service.dto.GetArticleResponse;
 import com.nest.core.post_management_service.exception.AddBookmarkFailException;
 import com.nest.core.post_management_service.exception.DeleteArticleFailException;
 import com.nest.core.post_management_service.exception.EditArticleFailException;
+import com.nest.core.post_management_service.exception.GetActivePermissionException;
 import com.nest.core.post_management_service.exception.RemoveBookmarkFailException;
 import com.nest.core.post_management_service.model.Post;
 import com.nest.core.post_management_service.model.PostTag;
 import com.nest.core.post_management_service.repository.PostRepository;
 import com.nest.core.post_management_service.repository.PostTagRepository;
+import com.nest.core.search_service.repository.SearchRepository;
+import com.nest.core.search_service.specification.PostSpecification;
 import com.nest.core.tag_management_service.model.Tag;
 import com.nest.core.tag_management_service.repository.TagRepository;
 import com.nest.core.topic_management_service.model.Topic;
@@ -25,11 +28,15 @@ import com.nest.core.topic_management_service.repository.TopicRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,6 +50,7 @@ public class ArticleService {
     private final TopicRepository topicRepository;
     private final TagRepository tagRepository;
     private final PostTagRepository postTagRepository;
+    private final SearchRepository searchRepository;
 
     @Transactional
     public void createArticle(CreateArticleRequest createArticleRequest, Long userId) {
@@ -163,5 +171,43 @@ public class ArticleService {
 
     public List<GetArticleResponse> getArticlesByUserId(Long userId){
         return postRepository.findAllArticlesByUserId(userId).stream().map(GetArticleResponse::new).collect(Collectors.toList());
+    }
+
+    public List<GetArticleResponse> getMostActiveArticles(Optional<Integer> count, Optional<String> region, String userRole)
+    {
+        if (!userRole.equals("ROLE_ADMIN") && !userRole.equals("ROLE_SUPER_ADMIN")) {
+            throw new GetActivePermissionException("Not authorized to get most active articles");
+        }
+        int limit = count.orElse(10);
+        Specification<Post> articleType = PostSpecification.isArticle();
+        if (region.isPresent()) {
+            Specification<Post> regionSpec = PostSpecification.fromRegion(region.get());
+            Specification<Post> spec = articleType.and(regionSpec);
+
+            List<Post> articles = searchRepository.findAll(spec);
+            articles.sort(
+                Comparator.comparingInt((Post post) -> post.getComments().size())
+                        .thenComparingLong(Post::getLikesCount)
+                        .thenComparingLong(Post::getViewCount)
+                        .reversed()
+            );
+            return articles.stream()
+                    .map(GetArticleResponse::new)
+                    .limit(limit)
+                    .collect(Collectors.toList());
+
+        } else {
+            List<Post> articles = searchRepository.findAll(articleType);
+            articles.sort(
+                Comparator.comparingInt((Post post) -> post.getComments().size())
+                        .thenComparingLong(Post::getLikesCount)
+                        .thenComparingLong(Post::getViewCount)
+                        .reversed()
+            );
+            return articles.stream()
+                    .map(GetArticleResponse::new)
+                    .limit(limit)
+                    .collect(Collectors.toList());
+        }
     }
 }

--- a/src/main/java/com/nest/core/post_management_service/service/PostService.java
+++ b/src/main/java/com/nest/core/post_management_service/service/PostService.java
@@ -11,6 +11,8 @@ import com.nest.core.post_management_service.model.PostTag;
 import com.nest.core.post_management_service.repository.PostImageRepository;
 import com.nest.core.post_management_service.repository.PostRepository;
 import com.nest.core.post_management_service.repository.PostTagRepository;
+import com.nest.core.search_service.repository.SearchRepository;
+import com.nest.core.search_service.specification.PostSpecification;
 import com.nest.core.tag_management_service.model.Tag;
 import com.nest.core.tag_management_service.repository.TagRepository;
 import com.nest.core.topic_management_service.model.Topic;
@@ -18,6 +20,8 @@ import com.nest.core.topic_management_service.repository.TopicRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -34,6 +38,7 @@ public class PostService {
     private final TopicRepository topicRepository;
     private final TagRepository tagRepository;
     private final PostTagRepository postTagRepository;
+    private final SearchRepository searchRepository;
 
     public void createPost(CreatePostRequest createPostRequest, Long userId) {
         Member member = findMemberById(userId);
@@ -202,6 +207,43 @@ public class PostService {
 
     public List<GetPostResponse> getPostsByUserId(Long userId){
         return postRepository.findAllPostsByUserId(userId).stream().map(GetPostResponse::new).collect(Collectors.toList());
+    }
+
+    public List<GetPostResponse> getMostActivePost(Optional<Integer> count, Optional<String> region, String userRole)
+    {
+        if (!userRole.equals("ROLE_ADMIN") && !userRole.equals("ROLE_SUPER_ADMIN")) {
+            throw new GetActivePermissionException("Not authorized to get most active articles");
+        }
+        int limit = count.orElse(10);
+        Specification<Post> postType = PostSpecification.isPost();
+        if (region.isPresent()) {
+            Specification<Post> regionSpec = PostSpecification.fromRegion(region.get());
+            Specification<Post> spec = postType.and(regionSpec);
+
+            List<Post> posts = searchRepository.findAll(spec);
+            posts.sort(
+                Comparator.comparingInt((Post post) -> post.getComments().size())
+                        .thenComparingLong(Post::getLikesCount)
+                        .thenComparingLong(Post::getViewCount)
+                        .reversed()
+            );
+            return posts.stream()
+                    .map(GetPostResponse::new)
+                    .limit(limit)
+                    .collect(Collectors.toList());
+        } else {
+            List<Post> posts = searchRepository.findAll(postType);
+            posts.sort(
+                Comparator.comparingInt((Post post) -> post.getComments().size())
+                        .thenComparingLong(Post::getLikesCount)
+                        .thenComparingLong(Post::getViewCount)
+                        .reversed()
+            );
+            return posts.stream()
+                    .map(GetPostResponse::new)
+                    .limit(limit)
+                    .collect(Collectors.toList());
+        }
     }
 
 }

--- a/src/main/java/com/nest/core/post_management_service/service/PostService.java
+++ b/src/main/java/com/nest/core/post_management_service/service/PostService.java
@@ -214,36 +214,20 @@ public class PostService {
         if (!userRole.equals("ROLE_ADMIN") && !userRole.equals("ROLE_SUPER_ADMIN")) {
             throw new GetActivePermissionException("Not authorized to get most active articles");
         }
-        int limit = count.orElse(10);
-        Specification<Post> postType = PostSpecification.isPost();
-        if (region.isPresent()) {
-            Specification<Post> regionSpec = PostSpecification.fromRegion(region.get());
-            Specification<Post> spec = postType.and(regionSpec);
+        Specification<Post> spec = PostSpecification.isPost();
+        if (region.isPresent()) spec = spec.and(PostSpecification.fromRegion(region.get()));
 
-            List<Post> posts = searchRepository.findAll(spec);
-            posts.sort(
-                Comparator.comparingInt((Post post) -> post.getComments().size())
-                        .thenComparingLong(Post::getLikesCount)
-                        .thenComparingLong(Post::getViewCount)
-                        .reversed()
-            );
-            return posts.stream()
-                    .map(GetPostResponse::new)
-                    .limit(limit)
-                    .collect(Collectors.toList());
-        } else {
-            List<Post> posts = searchRepository.findAll(postType);
-            posts.sort(
-                Comparator.comparingInt((Post post) -> post.getComments().size())
-                        .thenComparingLong(Post::getLikesCount)
-                        .thenComparingLong(Post::getViewCount)
-                        .reversed()
-            );
-            return posts.stream()
-                    .map(GetPostResponse::new)
-                    .limit(limit)
-                    .collect(Collectors.toList());
-        }
+        List<Post> posts = searchRepository.findAll(spec);
+        posts.sort(
+            Comparator.comparingInt((Post post) -> post.getComments().size())
+                    .thenComparingLong(Post::getLikesCount)
+                    .thenComparingLong(Post::getViewCount)
+                    .reversed()
+        );
+        return posts.stream()
+                .map(GetPostResponse::new)
+                .limit(count.orElse(10))
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/nest/core/search_service/specification/PostSpecification.java
+++ b/src/main/java/com/nest/core/search_service/specification/PostSpecification.java
@@ -3,6 +3,7 @@ package com.nest.core.search_service.specification;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 
+import com.nest.core.member_management_service.model.Member;
 import com.nest.core.post_management_service.model.Post;
 import com.nest.core.post_management_service.model.PostTag;
 import com.nest.core.search_service.exception.BadRequestException;
@@ -46,6 +47,13 @@ public class PostSpecification {
     public static Specification<Post> hasContent(String content) {
         return (root, query, criteriaBuilder) -> {
             return criteriaBuilder.like(root.get("content"), "%" + content + "%");
+        };
+    }
+
+    public static Specification<Post> fromRegion(String region) {
+        return (root, query, criteriaBuilder) -> {
+            Join<Post, Member> memberJoin = root.join("member");
+            return criteriaBuilder.equal(memberJoin.get("region"), region);
         };
     }
 


### PR DESCRIPTION
**Includes**
- /api/v1/posts/mostActive
- /api/v1/article/mostActive
- /api/v1/member/mostActive

**Request Params**
- count: the amount of entities to get (i.e. count = 20 gets top 20 most active back)
- region: the region of the poster (for posts/articles) or user

**Usage Examples:**
- /api/v1/posts/mostActive?count=5&region=south-america
- /api/v1/article/mostActive?count=20&region=europe
- /api/v1/member/mostActive?count=2&region=north-america

**Notes**
- Most active for users is defined as amounts of posts (both articles and user posts) followed by amounts of comments
- Most active posts/articles is defined as amounts of comments, then by likes, followed by view count
- Only admins and super admins can view most active users/posts/articles (assuming only these 2 roles have access to stats)
  - Maybe posts/articles could be open to all to implement what's popular right now? Future considerations though
- Did not add URL decoding in region (I assumed regions will follow the same naming scheme as north-america, south-america, etc.)
- Right now most active does not have a time limit (i.e. a 10 year old post with lots of comments is considered most active), essentially it's going to return all time most active
  - Issue is are we going to implement something like most active in past month, 3 months, 6 months, year, all time (i.e. variable time cutoffs)?