### PR TITLE
[NEST-BE-Fix] Add reset url to reset code request body

### DIFF
--- a/src/main/java/com/nest/core/password_management_service/controller/PasswordApiController.java
+++ b/src/main/java/com/nest/core/password_management_service/controller/PasswordApiController.java
@@ -38,7 +38,7 @@ public class PasswordApiController {
     @PostMapping("/forgot")
     public ResponseEntity<?> forgotPassword(@RequestBody SendResetCodeRequest codeRequest, HttpServletRequest request) {
         String resetUID = passwordService.generateResetToken(codeRequest);
-        mailService.sendResetUID(codeRequest.getEmail(), request.getHeader("Origin"), resetUID);
+        mailService.sendResetUID(codeRequest.getEmail(), codeRequest.getResetUrl(), resetUID);
         return ResponseEntity.ok("Reset token successfully sent to " + codeRequest.getEmail());
     }
 

--- a/src/main/java/com/nest/core/password_management_service/dto/SendResetCodeRequest.java
+++ b/src/main/java/com/nest/core/password_management_service/dto/SendResetCodeRequest.java
@@ -9,4 +9,5 @@ import lombok.Setter;
 @NoArgsConstructor
 public class SendResetCodeRequest {
     private String email;
+    private String resetUrl;
 }


### PR DESCRIPTION
- Moved the responsibility of generate the reset password link to the frontend (i.e. frontend needs to supply the link where the forget-password page is supposed to be)
- The reasoning is to try and decouple FE and BE (if FE decided to change the path to forget password, BE would have to modify the path too)
- The question is if there would be security risks doing this since this endpoint is accessible to everyone, but because the link is only being used to append the UUID, which in itself is being sent to an email I **THINK** it should be fine?